### PR TITLE
[#122]: 게임룸 입,퇴장 api

### DIFF
--- a/src/apps/lobby/components/Section.tsx
+++ b/src/apps/lobby/components/Section.tsx
@@ -1,5 +1,10 @@
+import clsx from 'clsx';
+import { RefreshCw } from 'lucide-react';
+import React, { useState } from 'react';
 import type { PropsWithChildren } from 'react';
-import React from 'react';
+
+import { queryClient } from '@/lib/queryClient';
+import { Button } from '@/shared/components/ui/button';
 
 export function LobbyScrollSection({
   children,
@@ -28,12 +33,38 @@ export function LobbyScrollSection({
   );
 }
 
-const Header = ({ children }: PropsWithChildren) => {
+const Header = ({
+  children,
+  refreshQuery,
+}: PropsWithChildren<{ refreshQuery?: string[] }>) => {
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const handleReset = async () => {
+    setIsRefreshing(true);
+    try {
+      await queryClient.invalidateQueries({ queryKey: refreshQuery });
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  const refreshClasses = clsx('cursor-pointer', {
+    'animate-spin': isRefreshing,
+  });
+
   return (
-    <header className="flex items-center justify-center px-3 sm:px-4 lg:px-6 py-3 sm:py-4 border-b border-gray-200 bg-gray-50 rounded-t-lg">
+    <header className="relative flex items-center justify-center px-3 sm:px-4 lg:px-6 py-3 sm:py-4 border-b border-gray-200 bg-gray-50 rounded-t-lg">
       <h2 className="text-base sm:text-lg font-semibold text-gray-800">
         {children}
       </h2>
+      <Button
+        className="absolute right-5 text-black bg-white hover:bg-gray-100"
+        onClick={handleReset}
+        aria-label="대기방 목록 새로고침"
+        disabled={isRefreshing}
+      >
+        <RefreshCw className={refreshClasses} />
+      </Button>
     </header>
   );
 };

--- a/src/apps/lobby/components/layouts/DesktopLayout.tsx
+++ b/src/apps/lobby/components/layouts/DesktopLayout.tsx
@@ -21,11 +21,11 @@ export default function DesktopLayout({
   participants,
 }: DesktopLayoutProps) {
   return (
-    <div className="grid grid-cols-20 gap-6 h-full">
+    <div className="grid grid-cols-30 gap-6 h-full">
       {/* 참여자 리스트 */}
-      <aside className="col-span-4 h-full" aria-label="온라인 사용자 목록">
+      <aside className="col-span-8 h-full" aria-label="온라인 사용자 목록">
         <LobbyScrollSection>
-          <LobbyScrollSection.Header>
+          <LobbyScrollSection.Header refreshQuery={['accounts']}>
             <div className="flex items-center gap-2 text-nowrap">
               <Users className="w-5 h-5" aria-hidden="true" />
               온라인 유저 ({participants.length})
@@ -66,9 +66,12 @@ export default function DesktopLayout({
       </aside> */}
 
       {/* 대기방 목록 */}
-      <section className="col-span-8 h-full" aria-label="대기 중인 게임방 목록">
+      <section
+        className="col-span-11 h-full"
+        aria-label="대기 중인 게임방 목록"
+      >
         <LobbyScrollSection>
-          <LobbyScrollSection.Header>
+          <LobbyScrollSection.Header refreshQuery={['game-rooms']}>
             <div className="flex items-center gap-2">
               <Users className="w-5 h-5" aria-hidden="true" />
               대기방 목록 ({waitingRooms.length})
@@ -87,9 +90,12 @@ export default function DesktopLayout({
       </section>
 
       {/* 진행중인 방 목록 */}
-      <section className="col-span-8 h-full" aria-label="진행 중인 게임방 목록">
+      <section
+        className="col-span-11 h-full"
+        aria-label="진행 중인 게임방 목록"
+      >
         <LobbyScrollSection>
-          <LobbyScrollSection.Header>
+          <LobbyScrollSection.Header refreshQuery={['']}>
             <div className="flex items-center gap-2">
               <Play className="w-5 h-5" aria-hidden="true" />
               진행중인 게임 ({playingRooms.length})

--- a/src/apps/lobby/components/layouts/MobileLayout.tsx
+++ b/src/apps/lobby/components/layouts/MobileLayout.tsx
@@ -30,7 +30,7 @@ export default function MobileLayout({
           aria-label="대기 중인 게임방 목록"
         >
           <LobbyScrollSection>
-            <LobbyScrollSection.Header>
+            <LobbyScrollSection.Header refreshQuery={['game-rooms']}>
               <div className="flex items-center gap-2">
                 <Users className="w-4 h-4 sm:w-5 sm:h-5" aria-hidden="true" />
                 <span className="text-sm sm:text-base">
@@ -56,7 +56,7 @@ export default function MobileLayout({
           aria-label="진행 중인 게임방 목록"
         >
           <LobbyScrollSection>
-            <LobbyScrollSection.Header>
+            <LobbyScrollSection.Header refreshQuery={['']}>
               <div className="flex items-center gap-2">
                 <Play className="w-4 h-4 sm:w-5 sm:h-5" aria-hidden="true" />
                 <span className="text-sm sm:text-base">
@@ -85,7 +85,7 @@ export default function MobileLayout({
           aria-label="온라인 사용자 목록"
         >
           <LobbyScrollSection>
-            <LobbyScrollSection.Header>
+            <LobbyScrollSection.Header refreshQuery={['accounts']}>
               <div className="flex items-center gap-2">
                 <Users className="w-4 h-4 sm:w-5 sm:h-5" aria-hidden="true" />
                 <span className="text-sm sm:text-base">

--- a/src/apps/room/[id]/index.tsx
+++ b/src/apps/room/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
 import { useParams, useNavigate } from '@tanstack/react-router';
 import { ArrowLeft } from 'lucide-react';
 import { toast } from 'react-toastify';
@@ -26,13 +26,18 @@ export default function GameRoomDetailPage() {
     staleTime: 1000 * 60 * 5,
   });
 
+  const { mutate: exitRoom } = useMutation(gameRoomQuery.exitRoom);
+
   const currentPlayer = room.members.find(
     (player) => player.accountId === currentUser.id
   );
   const isHost = currentPlayer?.role === 'host' || false;
 
   const handleBackToLobby = () => {
-    navigate({ to: '/lobby', replace: false });
+    if (confirm('정말로 나가시겠습니까?')) {
+      exitRoom(roomId);
+      navigate({ to: '/lobby', replace: false });
+    }
   };
 
   const canStartGame = room.members.length === room.maxMembersCount;

--- a/src/shared/service/api/query/room.ts
+++ b/src/shared/service/api/query/room.ts
@@ -4,6 +4,7 @@ import {
   createGameRoomControllerCreateGameRoom,
   getGameRoomControllerGetGameRoom,
   joinGameRoomControllerJoinGameRoom,
+  leaveGameRoomControllerLeaveGameRoom,
   listGameRoomsControllerListGameRooms,
 } from '@/lib/orval/_generated/quizzesGameIoBackend';
 import type {
@@ -18,6 +19,11 @@ export const gameRoomQuery = {
       queryFn: ({ queryKey }) =>
         listGameRoomsControllerListGameRooms(queryKey[1].options),
     }),
+  getDetail: (gameRoomId: string) =>
+    queryOptions({
+      queryKey: ['game-room', gameRoomId] as const,
+      queryFn: () => getGameRoomControllerGetGameRoom(gameRoomId),
+    }),
   createRoom: mutationOptions({
     mutationFn: ({ title, quizzesCount }: CreateGameRoomDto) => {
       return createGameRoomControllerCreateGameRoom({ title, quizzesCount });
@@ -26,9 +32,9 @@ export const gameRoomQuery = {
   joinRoom: mutationOptions({
     mutationFn: (roomId: string) => joinGameRoomControllerJoinGameRoom(roomId),
   }),
-  getDetail: (gameRoomId: string) =>
-    queryOptions({
-      queryKey: ['game-room', gameRoomId] as const,
-      queryFn: () => getGameRoomControllerGetGameRoom(gameRoomId),
-    }),
+  exitRoom: mutationOptions({
+    mutationFn: (roomId: string) =>
+      leaveGameRoomControllerLeaveGameRoom(roomId),
+    mutationKey: ['game-rooms', 'delete'],
+  }),
 };


### PR DESCRIPTION
## 📝 변경 사항

<!-- 이 PR에서 변경된 내용을 간단히 설명해주세요 -->
- 퇴장시 퇴장 api가 돌도록 추가했습니다.
- refresh버튼을 누르면 현재 활성화된 정보를 갱신합니다.

## 🔗 연관된 이슈

Closes #122

## 📱 스크린샷 (UI 변경 시)

<!-- UI가 변경된 경우 Before/After 스크린샷을 첨부해주세요 -->

### Before

<!-- 변경 전 스크린샷 -->

### After

<!-- 변경 후 스크린샷 -->
<img width="2032" height="1161" alt="스크린샷 2025-10-30 오후 12 23 15" src="https://github.com/user-attachments/assets/b160749a-d53c-4d81-be69-8df2544a20a6" />


## 📋 추가 정보

<!-- 리뷰어가 알아야 할 추가적인 정보가 있다면 작성해주세요 -->

### 리뷰 포인트

<!-- 특별히 리뷰받고 싶은 부분이 있다면 작성해주세요 -->

### 배포 시 주의사항

<!-- 배포할 때 주의해야 할 사항이 있다면 작성해주세요 -->

### Breaking Changes

<!-- 기존 코드나 API에 영향을 주는 변경사항이 있다면 작성해주세요 -->
